### PR TITLE
Update to functions used by yolotracker 

### DIFF
--- a/src/tracking_object_multi.cpp
+++ b/src/tracking_object_multi.cpp
@@ -7,13 +7,14 @@ namespace terraclear
         
     }
 
-    tracking_object_multi::tracking_object_multi(int max_sample_queue, int min_track_history, float min_track_velocity, int max_prediction_distance, int max_zero_velocity_count)
+    tracking_object_multi::tracking_object_multi(int max_sample_queue, int min_track_history, float min_track_velocity, int max_prediction_distance, int max_zero_velocity_count, int paddle_line)
     {
         _max_sample_queue = max_sample_queue;
         _min_track_history = min_track_history;
         _min_track_velocity = min_track_velocity;
         _max_prediction_distance = max_prediction_distance;
         _max_zero_vel_count = max_zero_velocity_count;
+        _paddle_line = paddle_line;
     }
     
     tracking_object_multi::~tracking_object_multi() 
@@ -91,14 +92,10 @@ namespace terraclear
                     regression_obj_y.queue_size = 30;
                     regression_obj_y.starting_pos = bbox.y;
                     regression_obj_y.time_reset_thresh = 4.0f;
-                    
-                    regression_obj_meta regression_obj_x;
-                    regression_obj_x.bbox = bbox;
-                    regression_obj_x.bbox_id = bbox.track_id;
-                    regression_obj_x.dest_pos = 1200;
-                    regression_obj_x.queue_size = 30;
+
+                    regression_obj_meta regression_obj_x = regression_obj_y;
                     regression_obj_x.starting_pos = bbox.x;
-                    regression_obj_x.time_reset_thresh = 4.0f;
+
                     
                     // Creates ptr to object tracking class
                     obj.obj_ptr = new tracking_object(regression_obj_x, regression_obj_y);
@@ -151,8 +148,8 @@ namespace terraclear
                     _tracking_list[keypair.first].obj_ptr->_frame_x_v = frame_v_x;
                     _tracking_list[keypair.first].obj_ptr->_frame_y_v = frame_v_y;
                     
-                    //predict next position
-                    if (use_frame_v)
+                    //predict next position using frame velocity if above paddle line else use individual linearly regressed vel
+                    if(_tracking_list[keypair.first].obj_found_count < _paddle_line)
                     {
                         _tracking_list[keypair.first].obj_ptr->predict_average();
                     }

--- a/src/tracking_object_multi.hpp
+++ b/src/tracking_object_multi.hpp
@@ -19,7 +19,7 @@ namespace terraclear
 
         public:
             tracking_object_multi();
-            tracking_object_multi(int max_sample_queue, int min_track_history, float min_track_velocity, int max_prediction_disance, int max_zero_velocity_count);
+            tracking_object_multi(int max_sample_queue, int min_track_history, float min_track_velocity, int max_prediction_disance, int max_zero_velocity_count, int paddle_line);
             virtual ~tracking_object_multi();
             std::vector<bounding_box> track(std::vector<bounding_box> objects, uint32_t min_abs_x_v = 0, uint32_t min_abs_y_v = 0,float frame_v_x = 0,float frame_v_y = 0, bool use_frame_v = true, bool remove_missing = false);
             
@@ -40,6 +40,7 @@ namespace terraclear
             int _max_prediction_distance = 10;
             float _stable_frame_vel = 0;
             int _max_zero_vel_count = 0;
+            int _paddle_line;
             
 
             bool boxes_contain_point(cv::Point source_point, std::vector<bounding_box> target_boxes);

--- a/src/vision_warp.cpp
+++ b/src/vision_warp.cpp
@@ -211,26 +211,18 @@ namespace  terraclear
 
         switch (patternType)
         {
-        case CHESSBOARD:
-        case CIRCLES_GRID:
-            //! [compute-chessboard-object-points]
-            for( int i = 0; i < boardSize.height; i++ )
-                for( int j = 0; j < boardSize.width; j++ )
-                    //To try to center the chessboard frame, we substract the image size
-                    objectPoints.push_back(cv::Point3f(float((j-boardSize.width/2)*squareSize),
-                                              float((i-boardSize.height/2)*squareSize), 0));
-            //! [compute-chessboard-object-points]
-            break;
+            case CHESSBOARD:
+                //! [compute-chessboard-object-points]
+                for( int i = 0; i < boardSize.height; i++ )
+                    for( int j = 0; j < boardSize.width; j++ )
+                        //To try to center the chessboard frame, we substract the image size
+                        objectPoints.push_back(cv::Point3f(float((j-boardSize.width/2)*squareSize),
+                                                float((i-boardSize.height/2)*squareSize), 0));
 
-        case ASYMMETRIC_CIRCLES_GRID:
-            for( int i = 0; i < boardSize.height; i++ )
-                for( int j = 0; j < boardSize.width; j++ )
-                    objectPoints.push_back(cv::Point3f(float((2*j + i % 2)*squareSize),
-                                              float(i*squareSize), 0));
-            break;
+                break;
 
-        default:
-            CV_Error(Error::StsBadArg, "Unknown pattern type\n");
+            default:
+                CV_Error(Error::StsBadArg, "Unknown pattern type\n");
         }
     }
 
@@ -268,8 +260,9 @@ namespace  terraclear
         _transform_matrix = cameraMatrix * _transform_matrix * cameraMatrix.inv();
         cv::Mat final_mat = _transform_matrix/_transform_matrix.at<double>(2,2);
         std::vector<cv::Point2f> worldPoints;
+        
         cv::perspectiveTransform(corners, worldPoints,final_mat);
-        _gsd = _block_size / abs(worldPoints[0].y - worldPoints[1].y) ;
+        _gsd = _block_size / abs(worldPoints[0].y - worldPoints[1].y);
 
         return final_mat;
             

--- a/src/vision_warp.cpp
+++ b/src/vision_warp.cpp
@@ -22,6 +22,7 @@ using namespace std;
 
 namespace  terraclear
 {   
+    vision_warp::vision_warp() {};
     vision_warp::vision_warp(std::string camera_xml) 
     {
         _sw.start();

--- a/src/vision_warp.cpp
+++ b/src/vision_warp.cpp
@@ -207,26 +207,18 @@ namespace  terraclear
 
         switch (patternType)
         {
-        case CHESSBOARD:
-        case CIRCLES_GRID:
-            //! [compute-chessboard-object-points]
-            for( int i = 0; i < boardSize.height; i++ )
-                for( int j = 0; j < boardSize.width; j++ )
-                    //To try to center the chessboard frame, we substract the image size
-                    objectPoints.push_back(cv::Point3f(float((j-boardSize.width/2)*squareSize),
-                                              float((i-boardSize.height/2)*squareSize), 0));
-            //! [compute-chessboard-object-points]
-            break;
+            case CHESSBOARD:
+                //! [compute-chessboard-object-points]
+                for( int i = 0; i < boardSize.height; i++ )
+                    for( int j = 0; j < boardSize.width; j++ )
+                        //To try to center the chessboard frame, we substract the image size
+                        objectPoints.push_back(cv::Point3f(float((j-boardSize.width/2)*squareSize),
+                                                float((i-boardSize.height/2)*squareSize), 0));
 
-        case ASYMMETRIC_CIRCLES_GRID:
-            for( int i = 0; i < boardSize.height; i++ )
-                for( int j = 0; j < boardSize.width; j++ )
-                    objectPoints.push_back(cv::Point3f(float((2*j + i % 2)*squareSize),
-                                              float(i*squareSize), 0));
-            break;
+                break;
 
-        default:
-            CV_Error(Error::StsBadArg, "Unknown pattern type\n");
+            default:
+                CV_Error(Error::StsBadArg, "Unknown pattern type\n");
         }
     }
 
@@ -264,8 +256,9 @@ namespace  terraclear
         _transform_matrix = cameraMatrix * _transform_matrix * cameraMatrix.inv();
         cv::Mat final_mat = _transform_matrix/_transform_matrix.at<double>(2,2);
         std::vector<cv::Point2f> worldPoints;
+        
         cv::perspectiveTransform(corners, worldPoints,final_mat);
-        _gsd = _block_size / abs(worldPoints[0].y - worldPoints[1].y) ;
+        _gsd = _block_size / abs(worldPoints[0].y - worldPoints[1].y);
 
         return final_mat;
             

--- a/src/vision_warp.cpp
+++ b/src/vision_warp.cpp
@@ -201,24 +201,32 @@ namespace  terraclear
         return cv::findChessboardCorners(_img, board_sz, corners);
     }
     
-    void vision_warp::calcChessboardCorners(cv::Size boardSize, float squareSize, terraclear::Pattern patternType = terraclear::Pattern::CHESSBOARD)
+    void vision_warp::calcChessboardCorners(cv::Size boardSize, terraclear::Pattern patternType = terraclear::Pattern::CHESSBOARD)
     {
         objectPoints.resize(0);
 
         switch (patternType)
         {
-            case CHESSBOARD:
-                //! [compute-chessboard-object-points]
-                for( int i = 0; i < boardSize.height; i++ )
-                    for( int j = 0; j < boardSize.width; j++ )
-                        //To try to center the chessboard frame, we substract the image size
-                        objectPoints.push_back(cv::Point3f(float((j-boardSize.width/2)*squareSize),
-                                                float((i-boardSize.height/2)*squareSize), 0));
+        case CHESSBOARD:
+        case CIRCLES_GRID:
+            //! [compute-chessboard-object-points]
+            for( int i = 0; i < boardSize.height; i++ )
+                for( int j = 0; j < boardSize.width; j++ )
+                    //To try to center the chessboard frame, we substract the image size
+                    objectPoints.push_back(cv::Point3f(float((j-boardSize.width/2)*_block_size),
+                                              float((i-boardSize.height/2)*_block_size), 0));
+            //! [compute-chessboard-object-points]
+            break;
 
-                break;
+        case ASYMMETRIC_CIRCLES_GRID:
+            for( int i = 0; i < boardSize.height; i++ )
+                for( int j = 0; j < boardSize.width; j++ )
+                    objectPoints.push_back(cv::Point3f(float((2*j + i % 2)*_block_size),
+                                              float(i*_block_size), 0));
+            break;
 
-            default:
-                CV_Error(Error::StsBadArg, "Unknown pattern type\n");
+        default:
+            CV_Error(Error::StsBadArg, "Unknown pattern type\n");
         }
     }
 

--- a/src/vision_warp.h
+++ b/src/vision_warp.h
@@ -55,7 +55,7 @@ namespace  terraclear
             void update_frame(const cv::Mat img_src);
             void undistort_img();
             bool findChessBoard(const cv::Size board_sz);
-            void calcChessboardCorners(cv::Size boardSize, float squareSize, terraclear::Pattern patternType);
+            void calcChessboardCorners(cv::Size boardSize, terraclear::Pattern patternType);
             void computeC2MC1(const cv::Mat &R1, const cv::Mat &tvec1, const cv::Mat &R2, const cv::Mat &tvec2, cv::Mat &R_1to2, cv::Mat &tvec_1to2);
             cv::Mat init_transform();
             

--- a/src/vision_warp.h
+++ b/src/vision_warp.h
@@ -39,6 +39,7 @@ namespace  terraclear
             };
 
         public:
+            vision_warp();
             vision_warp(std::string camera_xml);
             virtual ~vision_warp();
 


### PR DESCRIPTION
In an issue pointed out by Bishop, the rock predictions lag behind the rock trajectory past the paddle line. This is because the camera frame velocity is slightly slower towards the top of the frame due to the distortion effects of the perspective transform. 

Therefore using the linearly regressed velocities of the individual rocks to predict position past the paddle line should yield more accurate predictions. 

We will still use the camera velocity to predict the rock positions before the paddle line. 
